### PR TITLE
La content sette max høyde til orginal størrelsen

### DIFF
--- a/src/components/tab-menu/tab-menu.less
+++ b/src/components/tab-menu/tab-menu.less
@@ -4,6 +4,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
+	min-height: 0;
 
 	&__headers {
 		display: flex;
@@ -29,6 +30,7 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
+		min-height: 0;
 	}
 
 	&__tab-content--aktivitetsplan {

--- a/src/index.less
+++ b/src/index.less
@@ -20,4 +20,5 @@ body {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-height: 0;
 }


### PR DESCRIPTION
Ønsker at dialogen skal være 100% av parent tabben og ikke større. For å få til dette så må vi gjøre følgende endring. For info se her.
https://stackoverflow.com/questions/34144972/flexbox-avoid-child-with-longer-height-than-parent-column-direction

En child component kan fint være større, men setter de 100% så får de 100% av plassen som er igjen på skjermen. 

