### PR TITLE
Refresh med enhet i url

### DIFF
--- a/src/components/internflate-decorator/internflate-decorator-utils.ts
+++ b/src/components/internflate-decorator/internflate-decorator-utils.ts
@@ -1,4 +1,4 @@
-import { refreshMedNyFnrIUrl } from '../../utils/url-utils';
+import { refreshMedNyEnhetIUrl, refreshMedNyFnrIUrl } from '../../utils/url-utils';
 import { DecoratorConfig, EnhetDisplay, FnrDisplay } from './internflate-decorator-config';
 
 export function lagDecoratorConfig(
@@ -31,8 +31,13 @@ export function lagDecoratorConfig(
 			value: enhet,
 			skipModal: true,
 			ignoreWsEvents: true,
-			// tslint:disable-next-line:no-empty
-			onChange: (newEnhet: string | null) => {}
+			onChange: (newEnhet: string | null) => {
+				if (enhet !== enhetId && newEnhet != null) {
+					//  TODO: Når apper går over til å kun bruke enhet fra props og ikke henter fra URL
+					//   så burde vi ikke laste inn siden på nytt og istedenfor endre på propsene som blir sendt videre ned
+					refreshMedNyEnhetIUrl(newEnhet);
+				}
+			}
 		}
 	};
 }


### PR DESCRIPTION
Siden vi henter enhet fra URL og sender det videre til microfrontends så må vi refreshe siden og legge på enhet hvis ikke enhet allerede er satt i URLen