### PR TITLE
Godtar cdn.sanity.io i csp

### DIFF
--- a/.nais/poao-nais-dev.yaml
+++ b/.nais/poao-nais-dev.yaml
@@ -61,7 +61,7 @@ spec:
           },
           "header": {
             "csp": {
-              "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no"]
+              "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no", "cdn.sanity.io"]
             }
           },
           "redirects": [

--- a/.nais/poao-nais-prod.yaml
+++ b/.nais/poao-nais-prod.yaml
@@ -58,7 +58,7 @@ spec:
           },
           "header": {
             "csp": {
-              "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no"]
+              "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no", "cdn.sanity.io"]
             }
           },
           "redirects": [


### PR DESCRIPTION
Team Valp henter noen filer som ligger på Sanity. Vi trenger derfor å godkjenne cdn.sanity.io i csp-reglene.