### PR TITLE
Allow video from qbrick in csp

### DIFF
--- a/.nais/poao-nais-dev.yaml
+++ b/.nais/poao-nais-dev.yaml
@@ -63,7 +63,8 @@ spec:
           },
           "header": {
             "csp": {
-              "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no", "cdn.sanity.io"]
+              "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no", "cdn.sanity.io"],
+              "frameSrc": ["vars.hotjar.com", "video.qbrick.com"]
             }
           },
           "redirects": [

--- a/.nais/poao-nais-prod.yaml
+++ b/.nais/poao-nais-prod.yaml
@@ -58,7 +58,8 @@ spec:
           },
           "header": {
             "csp": {
-              "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no", "cdn.sanity.io"]
+              "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no", "cdn.sanity.io"],
+              "frameSrc": ["vars.hotjar.com", "video.qbrick.com"]
             }
           },
           "redirects": [


### PR DESCRIPTION
Aktivitetsplanen bruker en video fra Qbrick som er blokkert, CSP kan ikke settes i aktivitetsplanen siden det ikke er der "execution contexten"-en blir laget men i veilarbpersonflate

https://www.w3.org/TR/2015/CR-CSP2-20150721/#which-policy-applies
TLDR: Bare CSP fra veilarbpersonflate kommer til å bli brukt