### PR TITLE
Fjern proxy-oppsett og access policy for poao-unleash

### DIFF
--- a/.nais/poao-nais-dev.yaml
+++ b/.nais/poao-nais-dev.yaml
@@ -45,7 +45,6 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: poao-unleash
         - application: mulighetsrommet-api
           namespace: team-mulighetsrommet
         - application: obo-unleash
@@ -161,16 +160,6 @@ spec:
                 "name": "veilarbportefolje",
                 "namespace": "pto",
                 "cluster": "dev-fss"
-              }
-            },
-            {
-              "fromPath": "/veilarbpersonflatefs",
-              "toUrl": "http://poao-unleash.poao.svc.cluster.local",
-              "preserveFromPath": false,
-               "toApp": {
-                "name": "poao-unleash",
-                "namespace": "poao",
-                "cluster": "dev-gcp"
               }
             },
             {

--- a/.nais/poao-nais-prod.yaml
+++ b/.nais/poao-nais-prod.yaml
@@ -45,7 +45,6 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: poao-unleash
         - application: mulighetsrommet-api
           namespace: team-mulighetsrommet
         - application: obo-unleash
@@ -161,16 +160,6 @@ spec:
                 "name": "veilarblest",
                 "namespace": "pto",
                 "cluster": "prod-fss"
-              }
-            },
-            {
-              "fromPath": "/veilarbpersonflatefs",
-              "toUrl": "http://poao-unleash.poao.svc.cluster.local",
-              "preserveFromPath": false,
-               "toApp": {
-                "name": "poao-unleash",
-                "namespace": "poao",
-                "cluster": "prod-gcp"
               }
             },
             {


### PR DESCRIPTION
Oppsettet trengs ikke lenger nå når alle team er migrert til egne instanser av Unleash Next.