### PR TITLE
Legg tilbake overskrevne csp-verdier

### DIFF
--- a/.nais/poao-nais-dev.yaml
+++ b/.nais/poao-nais-dev.yaml
@@ -84,7 +84,7 @@ spec:
             "csp": {
               "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no", "cdn.sanity.io", "storage.googleapis.com"],
               "frameSrc": ["vars.hotjar.com", "video.qbrick.com"],
-              "imgSrc": ["'self'", "*.nav.no", "cdn.sanity.io"]
+              "imgSrc": ["'self'", "data:", "*.nav.no", "*.adeo.no", "cdn.sanity.io"]
             }
           },
           "redirects": [

--- a/.nais/poao-nais-prod.yaml
+++ b/.nais/poao-nais-prod.yaml
@@ -82,7 +82,7 @@ spec:
             "csp": {
               "connectSrc": ["'self'", "wss:", "*.nav.no", "*.adeo.no", "cdn.sanity.io", "storage.googleapis.com"],
               "frameSrc": ["vars.hotjar.com", "video.qbrick.com"],
-              "imgSrc": ["'self'", "*.nav.no", "cdn.sanity.io"]
+              "imgSrc": ["'self'", "data:", "*.nav.no", "*.adeo.no", "cdn.sanity.io"]
             }
           },
           "redirects": [

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package.json
+package-lock.json
+tsconfig.json


### PR DESCRIPTION
Da imgSrc ble lagt til i csp-headeren så ble [default-verdiene](https://github.com/navikt/poao-frontend/blob/main/src/config/header-config.ts#L22) overskrevet