### PR TITLE
Fjerner toggle for Arbeidsmarkedstiltak for Team Valp

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -65,13 +65,6 @@ export function useFetchFeaturesFromOboUnleash(): UseAxiosResponseValue<OboUnlea
 	return useAxios<OboUnleashFeatures>(`/obo-unleash/api/feature?${toggles}`);
 }
 
-export function useFetchFeaturesForTeamValp(options?: Options): UseAxiosResponseValue<boolean> {
-	return useAxios<boolean>(
-		`/mulighetsrommet-api/api/v1/internal/features?feature=${ARBEIDSMARKEDSTILTAK_LANSERING}`,
-		options
-	);
-}
-
 export function useFetchFeaturesFromDabUnleash(): UseAxiosResponseValue<DabUnleashFeatures> {
 	const toggles = DAB_UNLEASH_TOGGLES.map(element => 'feature=' + element).join('&');
 	return useAxios<DabUnleashFeatures>(`/veilarbaktivitet/api/feature?${toggles}`);

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -1,4 +1,3 @@
-export const ARBEIDSMARKEDSTILTAK_LANSERING = 'mulighetsrommet-veileder-flate.lansering';
 export const VIS_GAMLE_DETALJER_FANE = 'veilarbpersonflatefs.vis-gamle-detaljer-fane';
 export const DIALOG_WEBSOCKET = 'veilarbpersonflatefs.dialog.websockets';
 

--- a/src/component/side-innhold.tsx
+++ b/src/component/side-innhold.tsx
@@ -17,7 +17,6 @@ import TabMenu, { Tab } from './tab-menu/tab-menu';
 
 interface SideInnholdLayoutProps {
 	oboUnleashFeatures?: OboUnleashFeatures;
-	enableArbeidsmarkedstiltakForTeamValp?: boolean;
 }
 
 export enum TabId {
@@ -88,7 +87,7 @@ class SideInnhold extends React.Component<SideInnholdLayoutProps> {
 
 	render() {
 		const { aktivBrukerFnr, aktivEnhetId } = this.context;
-		const { enableArbeidsmarkedstiltakForTeamValp, oboUnleashFeatures } = this.props;
+		const { oboUnleashFeatures } = this.props;
 		const tabs: Tab[] = [];
 
 		tabs.push({
@@ -120,7 +119,7 @@ class SideInnhold extends React.Component<SideInnholdLayoutProps> {
 			className: 'tab-menu__tab-content--vedtaksstotte'
 		});
 
-		if (isArbeidsmarkedstiltakFaneEnabled(enableArbeidsmarkedstiltakForTeamValp, aktivEnhetId)) {
+		if (vikafossenIkkeErValgtSomEnhet(aktivEnhetId)) {
 			tabs.push({
 				id: TabId.ARBEIDSMARKEDSTILTAK,
 				title: 'Arbeidsmarkedstiltak',
@@ -148,11 +147,7 @@ class SideInnhold extends React.Component<SideInnholdLayoutProps> {
 	}
 }
 
-function isArbeidsmarkedstiltakFaneEnabled(featureEnabled: boolean | undefined, enhet: string | null) {
-	if (!featureEnabled) {
-		return false;
-	}
-
+function vikafossenIkkeErValgtSomEnhet(enhet: string | null) {
 	// Et lite unntak mens Team Valp venter på PVO
 	const vikafossen = '2103';
 	return enhet && enhet !== vikafossen;

--- a/src/page/personflate.tsx
+++ b/src/page/personflate.tsx
@@ -9,7 +9,6 @@ import PageSpinner from '../component/page-spinner/page-spinner';
 import { InternflateDecorator } from '../component/internflate-decorator/internflate-decorator';
 import {
 	useFetchAktivEnhet,
-	useFetchFeaturesForTeamValp,
 	useFetchFeaturesFromOboUnleash,
 	useFetchTilgangTilBruker
 } from '../api/api';
@@ -26,7 +25,6 @@ export const PersonflatePage = () => {
 
 	const fetchTilgangTilBruker = useFetchTilgangTilBruker(aktivBrukerFnr, { manual: true });
 	const fetchOboUnleashFeatures = useFetchFeaturesFromOboUnleash();
-	const arbeidsmarkedstiltakForTeamValpFeature = useFetchFeaturesForTeamValp();
 	const fetchAktivEnhet = useFetchAktivEnhet();
 
 	// Hack used because internflatedecorator does not update onFnrChanged function so comparison on fnr can not
@@ -69,12 +67,11 @@ export const PersonflatePage = () => {
 		isAnyLoading(
 			fetchTilgangTilBruker,
 			fetchAktivEnhet,
-			arbeidsmarkedstiltakForTeamValpFeature,
 			fetchOboUnleashFeatures
 		)
 	) {
 		innhold = <PageSpinner />;
-	} else if (hasAnyFailed(fetchTilgangTilBruker, arbeidsmarkedstiltakForTeamValpFeature, fetchOboUnleashFeatures)) {
+	} else if (hasAnyFailed(fetchTilgangTilBruker, fetchOboUnleashFeatures)) {
 		innhold = <FeilUnderLastingAvData />;
 	} else if (!fetchTilgangTilBruker.data) {
 		innhold = <IngenTilgangTilBruker />;
@@ -82,7 +79,6 @@ export const PersonflatePage = () => {
 		innhold = (
 			<Innhold
 				oboUnleashFeatures={fetchOboUnleashFeatures.data}
-				enableArbeidsmarkedstiltakForTeamValp={arbeidsmarkedstiltakForTeamValpFeature.data}
 			/>
 		);
 	}
@@ -103,14 +99,12 @@ export const PersonflatePage = () => {
 
 interface AppInnholdProps {
 	oboUnleashFeatures?: OboUnleashFeatures;
-	enableArbeidsmarkedstiltakForTeamValp?: boolean;
 }
 
-const Innhold = ({ oboUnleashFeatures, enableArbeidsmarkedstiltakForTeamValp }: AppInnholdProps) => {
+const Innhold = ({ oboUnleashFeatures }: AppInnholdProps) => {
 	return (
 		<SideInnhold
 			oboUnleashFeatures={oboUnleashFeatures}
-			enableArbeidsmarkedstiltakForTeamValp={enableArbeidsmarkedstiltakForTeamValp}
 		/>
 	);
 };


### PR DESCRIPTION
Alle enheter kan få se fanen Arbeidsmarkedstiltak i Modia, bortsett fra NAV Vikafossen
