### PR TITLE
Skeleton loader for arbeidsmarkedstiltak

### DIFF
--- a/src/component/spa.tsx
+++ b/src/component/spa.tsx
@@ -6,7 +6,7 @@ import Spinner from './spinner/spinner';
 import { AssetManifestParser, loadAssets } from '@navikt/navspa/dist/async/async-navspa';
 import { Env, getEnv } from '../util/utils';
 import { createAssetManifestParser } from '@navikt/navspa/dist/async/utils';
-import { Loader } from '@navikt/ds-react';
+import { HStack, Loader, Skeleton, VStack } from '@navikt/ds-react';
 
 export interface SpaProps {
 	enhet?: string;
@@ -145,7 +145,22 @@ export const Arbeidsmarkedstiltak: React.ComponentType<SpaProps> = props => {
 		}).finally(() => setIsLoading(false));
 	}, []);
 	return isLoading ? (
-		<Loader>Laster...</Loader>
+		<HStack>
+			<VStack gap="2">
+				<Skeleton height={50} variant="rounded" />
+				<Skeleton height={50} variant="rounded" />
+				<Skeleton height={200} variant="rounded" />
+				<Skeleton height={110} variant="rounded" />
+				<Skeleton height={110} variant="rounded" />
+			</VStack>
+			<VStack>
+				<Skeleton height={50} variant="rounded" />
+				<Skeleton height={100} variant="rounded" />
+				<Skeleton height={100} variant="rounded" />
+				<Skeleton height={100} variant="rounded" />
+				<Skeleton height={50} variant="rounded" />
+			</VStack>
+		</HStack>
 	) : (
 		React.createElement('mulighetsrommet-arbeidsmarkedstiltak', {
 			'data-fnr': props.fnr,

--- a/src/component/spa.tsx
+++ b/src/component/spa.tsx
@@ -1,11 +1,12 @@
 import NAVSPA, { AsyncNavspa, AsyncSpaConfig } from '@navikt/navspa';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { utledCdnUrl, utledSpaUrl } from '../util/url-utils';
 import { DecoratorConfig } from './internflate-decorator/internflate-decorator-config';
 import Spinner from './spinner/spinner';
 import { AssetManifestParser, loadAssets } from '@navikt/navspa/dist/async/async-navspa';
 import { Env, getEnv } from '../util/utils';
 import { createAssetManifestParser } from '@navikt/navspa/dist/async/utils';
+import { Loader } from '@navikt/ds-react';
 
 export interface SpaProps {
 	enhet?: string;
@@ -128,24 +129,29 @@ export const Dialog: React.ComponentType<SpaProps> = props => {
 	return React.createElement('dab-dialog', { ['data-fnr']: props.fnr });
 };
 
-const arbeidsmarkedstiltakBaseUrl = utledCdnUrl("mulighetsrommet/arbeidsmarkedstiltak-modia/dist");
+const arbeidsmarkedstiltakBaseUrl = utledCdnUrl('mulighetsrommet/arbeidsmarkedstiltak-modia/dist');
 const arbeidsmarkedstiltakManifestParser: AssetManifestParser = manifest => {
 	const { file } = manifest['index.html'];
 	const entry = { type: 'module', path: `${arbeidsmarkedstiltakBaseUrl}/${file}` };
 	return [entry];
 };
 export const Arbeidsmarkedstiltak: React.ComponentType<SpaProps> = props => {
+	const [isLoading, setIsLoading] = useState(true);
 	useEffect(() => {
 		loadAssets({
 			appName: SpaName.ARBEIDSMARKEDSTILTAK,
 			appBaseUrl: arbeidsmarkedstiltakBaseUrl,
 			assetManifestParser: arbeidsmarkedstiltakManifestParser
-		});
+		}).finally(() => setIsLoading(false));
 	}, []);
-	return React.createElement('mulighetsrommet-arbeidsmarkedstiltak', {
-		'data-fnr': props.fnr,
-		'data-enhet': props.enhet
-	});
+	return isLoading ? (
+		<Loader>Laster...</Loader>
+	) : (
+		React.createElement('mulighetsrommet-arbeidsmarkedstiltak', {
+			'data-fnr': props.fnr,
+			'data-enhet': props.enhet
+		})
+	);
 };
 
 export const finnStillingInngangAsyncConfig: AsyncSpaConfig = {
@@ -170,11 +176,9 @@ export const Decorator: React.ComponentType<DecoratorConfig> = NAVSPA.importer(S
 	wrapperClassName: ''
 });
 
-export const Visittkort: React.ComponentType<VisittKortProps> = AsyncNavspa.importer<VisittKortProps>(
-	visittkortAsyncConfig
-);
+export const Visittkort: React.ComponentType<VisittKortProps> =
+	AsyncNavspa.importer<VisittKortProps>(visittkortAsyncConfig);
 export const Detaljer: React.ComponentType<SpaProps> = AsyncNavspa.importer<SpaProps>(detaljerAsyncConfig);
 export const Vedtaksstotte: React.ComponentType<SpaProps> = AsyncNavspa.importer<SpaProps>(vedtaksstotteAsyncConfig);
-export const FinnStillingInngang: React.ComponentType<SpaProps> = AsyncNavspa.importer<SpaProps>(
-	finnStillingInngangAsyncConfig
-);
+export const FinnStillingInngang: React.ComponentType<SpaProps> =
+	AsyncNavspa.importer<SpaProps>(finnStillingInngangAsyncConfig);


### PR DESCRIPTION
Legger til et skeleton som skal simulere appen til Valp (Arbeidsmarkedstiltak) slik at veilederne ikke bare ser en grå skjerm, men får et inntrykk av at appen laster.