### PR TITLE
Legg til bygg-sjekk på PR-ar

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,23 @@
+name: Sjekk PR-kode
+
+on: pull_request
+
+jobs:
+  build-application:
+    name: Build application
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm run test
+      - name: Build application
+        run: npm run build


### PR DESCRIPTION
**Bakgrunn:** 
Gjere det lettare å oppdagar feil som har oppstått mellom testing/review og merge.

**Døme på når dette er nyttig:** 
Du skriv om noko kode du fekk tilbakemeldingar på og gløymer å fjerne ubrukte importar. Fordi endringa er triviell droppar du ei ny runde med deploy-to-dev og har gløymd å sjekke for warnings i konsollen. Linting på greina gjer at bygg feiler på ubrukte importar. Du må rulle attende eller lage ny PR for å fikse bygginga att.
Å få beskjed om dette allereie i PR-en sparer litt tid, fordi problemet vert tydeleg før merge.

(Dømet er henta frå `veilarbportefoljeflatefs`. Det er ikkje sikkert vi har like streng linting her.)