### PR TITLE
Setter opp alarmer for bedre overvåking

### DIFF
--- a/.github/actions/lint-yaml/action.yaml
+++ b/.github/actions/lint-yaml/action.yaml
@@ -1,0 +1,20 @@
+name: Lint YAML
+description: Runs yamllint on the specified input
+inputs:
+  path:
+    description: Path to yaml
+    required: true
+  config:
+    description: |
+      Configuration passed to yamllint.
+      Docs: https://yamllint.readthedocs.io/en/stable/configuration.html#custom-configuration-without-a-config-file
+    required: true
+    default: relaxed
+
+runs:
+  using: composite
+  steps:
+    - name: Lint
+      shell: bash
+      run: |
+        yamllint -f github -d ${{ inputs.config }} ${{ inputs.path }}

--- a/.github/workflows/deploy-alerts.yaml
+++ b/.github/workflows/deploy-alerts.yaml
@@ -1,0 +1,40 @@
+name: Deploy alerts
+
+on:
+    push:
+        paths:
+            - .github/workflows/deploy-alerts.yaml
+            - iac/alerts/**
+
+jobs:
+    ci:
+        name: CI
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Lint
+              uses: ./.github/actions/lint-yaml
+              with:
+                  path: iac/alerts
+
+    deploy-alerts:
+        name: Apply alerts to cluster
+        runs-on: ubuntu-latest
+        needs: [ci]
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        permissions:
+            id-token: write # Needed for `nais/deploy/actions/deploy`
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: deploy to dev
+              uses: nais/deploy/actions/deploy@v2
+              env:
+                  CLUSTER: dev-gcp
+                  RESOURCE: iac/alerts/alerts-dev.yaml
+            - name: deploy to prod
+              uses: nais/deploy/actions/deploy@v2
+              env:
+                  CLUSTER: prod-gcp
+                  RESOURCE: iac/alerts/alerts-prod.yaml

--- a/iac/alerts/alerts-dev.yaml
+++ b/iac/alerts/alerts-dev.yaml
@@ -1,0 +1,41 @@
+# Se docs for hvordan definere rules:
+# - https://docs.nais.io/observability/alerting/
+# - https://docs.nais.io/observability/alerting/reference/prometheusrule/#prometheusrule
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: veilarbpersonflate-alerts
+  namespace: poao
+  labels:
+    team: poao
+spec:
+  groups:
+    - name: Deployment
+      rules:
+        - alert: applikasjon nede
+          expr: kube_deployment_status_replicas_available{deployment="veilarbpersonflate"} == 0
+          for: 12m
+          annotations:
+            consequence: "'{{ $labels.deployment }}' er utilgjengelig"
+            action: "`kubectl describe pod -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for events, og `kubectl logs -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for logger"
+            summary: |-
+              '{{ $labels.deployment }}' er utilgjengelig. Dette burde fikses asap!
+
+              Dette kan ha skjedd som følge av endringer i NAIS config eller at det er noe galt i plattformen.
+          labels:
+            namespace: poao
+            severity: critical
+        - alert: "Applikasjon starter ikke"
+          expr: kube_deployment_status_replicas_unavailable{deployment="veilarbpersonflate"} > 0
+          for: 5m
+          annotations:
+            consequence: Minst én pod er utilgjengelig og nye kodeendringer har sannsynligvis ikke blitt produksjonssatt.
+            action: "`kubectl describe pod -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for events, og `kubectl logs -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for logger"
+            summary: |
+              '{{ $labels.deployment }}' kunne ikke startes og har sannsynligvis havnet i CrashLoopBackoff under deployment.
+
+              Sjekk loggene for å finne ut hva som er galt.
+          labels:
+            namespace: poao
+            severity: critical

--- a/iac/alerts/alerts-prod.yaml
+++ b/iac/alerts/alerts-prod.yaml
@@ -1,0 +1,41 @@
+# Se docs for hvordan definere rules:
+# - https://docs.nais.io/observability/alerting/
+# - https://docs.nais.io/observability/alerting/reference/prometheusrule/#prometheusrule
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: veilarbpersonflate-alerts
+  namespace: poao
+  labels:
+    team: poao
+spec:
+  groups:
+    - name: Deployment
+      rules:
+        - alert: applikasjon nede
+          expr: kube_deployment_status_replicas_available{deployment="veilarbpersonflate"} == 0
+          for: 1m
+          annotations:
+            consequence: "'{{ $labels.deployment }}' er utilgjengelig"
+            action: "`kubectl describe pod -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for events, og `kubectl logs -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for logger"
+            summary: |-
+              '{{ $labels.deployment }}' er utilgjengelig. Dette burde fikses asap!
+
+              Dette kan ha skjedd som følge av endringer i NAIS config eller at det er noe galt i plattformen.
+          labels:
+            namespace: poao
+            severity: critical
+        - alert: "Applikasjon starter ikke"
+          expr: kube_deployment_status_replicas_unavailable{deployment="veilarbpersonflate"} > 0
+          for: 5m
+          annotations:
+            consequence: Minst én pod er utilgjengelig og nye kodeendringer har sannsynligvis ikke blitt produksjonssatt.
+            action: "`kubectl describe pod -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for events, og `kubectl logs -l app={{ $labels.deployment }} -n {{ $labels.namespace }}` for logger"
+            summary: |
+              '{{ $labels.deployment }}' kunne ikke startes og har sannsynligvis havnet i CrashLoopBackoff under deployment.
+
+              Sjekk loggene for å finne ut hva som er galt.
+          labels:
+            namespace: poao
+            severity: critical


### PR DESCRIPTION
Setter opp følgende alarmer for veilarbpersonflate:
- Alarm dersom ingen replica av appen er tilgjengelig
- Alarm dersom minst én replica ikke svarer på Nais-plattformen


Alarmene er satt opp til å gå mot #poao-tech på Slack (default alarm for poao-namespacet).

