### PR TITLE
Oppdater modiacontextholder-url

### DIFF
--- a/.nais/poao-nais-dev.yaml
+++ b/.nais/poao-nais-dev.yaml
@@ -84,7 +84,6 @@ spec:
         - host: veilarbperson.dev-fss-pub.nais.io
         - host: veilarboppfolging.dev-fss-pub.nais.io
         - host: veilarbportefolje.dev-fss-pub.nais.io
-        - host: modiacontextholder-q1.dev-fss-pub.nais.io
         - host: veilarbveileder.dev-fss-pub.nais.io
         - host: veilarbvedtaksstotte.dev-fss-pub.nais.io
         - host: amplitude.nav.no
@@ -202,7 +201,7 @@ spec:
             },
             {
               "fromPath": "/modiacontextholder",
-              "toUrl": "http://modiacontextholder.personoversikt.svc.cluster.local",
+              "toUrl": "http://modiacontextholder.personoversikt",
               "preserveFromPath": false,
               "toApp": {
                 "name": "modiacontextholder",

--- a/.nais/poao-nais-prod.yaml
+++ b/.nais/poao-nais-prod.yaml
@@ -78,7 +78,6 @@ spec:
         - host: veilarbperson.prod-fss-pub.nais.io
         - host: veilarboppfolging.prod-fss-pub.nais.io
         - host: veilarbaktivitet.prod-fss-pub.nais.io
-        - host: modiacontextholder.prod-fss-pub.nais.io
         - host: veilarbveileder.prod-fss-pub.nais.io
         - host: veilarbvedtaksstotte.prod-fss-pub.nais.io
         - host: amplitude.nav.no
@@ -206,7 +205,7 @@ spec:
             },
             {
               "fromPath": "/modiacontextholder",
-              "toUrl": "http://modiacontextholder.personoversikt.svc.cluster.local",
+              "toUrl": "http://modiacontextholder.personoversikt",
               "preserveFromPath": false,
               "toApp": {
                 "name": "modiacontextholder",

--- a/src/component/internflate-decorator/internflate-decorator.tsx
+++ b/src/component/internflate-decorator/internflate-decorator.tsx
@@ -34,9 +34,7 @@ function getDecoratorEnv(): DecoratorEnvironment {
 	}
 }
 
-function lagDecoratorConfig(
-	props: InternflateDecoratorProps
-): DecoratorConfigV2 & { proxy: string; useProxy: boolean } {
+function lagDecoratorConfig(props: InternflateDecoratorProps): DecoratorConfigV2 {
 	const fnr = props.fnr ?? undefined;
 	const enhetId = props.enhetId ?? undefined;
 	return {
@@ -44,8 +42,6 @@ function lagDecoratorConfig(
 		enhet: enhetId,
 		onEnhetChanged: newEnhet => props.onEnhetChanged(newEnhet ?? null),
 		onFnrChanged: newFnr => props.onFnrChanged(newFnr ?? null),
-		useProxy: true,
-		proxy: '/modiacontextholder',
 		environment: getDecoratorEnv(),
 		fetchActiveUserOnMount: true,
 		fetchActiveEnhetOnMount: true,

--- a/src/mock/api/handlers.ts
+++ b/src/mock/api/handlers.ts
@@ -74,9 +74,9 @@ export const handlers = [
 	),
 	http.post('/veilarbdialog/api/dialog/antallUleste', responseResolver({ json: mockAntallUleste })),
 	http.post('/veilarbdialog/api/dialog/sistOppdatert', responseResolver({ json: mockSistOppdatert })),
-	http.get('/modiacontextholder/api/context/aktivenhet', responseResolver({ json: mockAktivEnhet })),
-	http.get('/modiacontextholder/api/context/v2/aktivenhet', responseResolver({ json: mockAktivEnhet })),
-	http.post('/modiacontextholder/api/context', responseResolver({ json: mockAktivEnhet })),
+	http.get('/api/context/aktivenhet', responseResolver({ json: mockAktivEnhet })),
+	http.get('/api/context/v2/aktivenhet', responseResolver({ json: mockAktivEnhet })),
+	http.post('/api/context', responseResolver({ json: mockAktivEnhet })),
 	http.get('/veilarbperson/api/v3/person/hent-tilgangTilBruker', responseResolver({ json: mockTilgangTilBruker })),
 	http.post('/veilarboppfolging/api/v3/manuell/synkroniser-med-dkif', responseResolver({ status: 204 })),
 


### PR DESCRIPTION
Ref. [denne Slack-tråden](https://nav-it.slack.com/archives/CLJJKQEHY/p1720163651664939). Personflate ligger i Grafana-boardet under "requests med gammel path" i kolonnen "/modiacontextholder/api/context", må vi fjerne proxyen? 🤷‍♂️ 
Mulig det bare er noe gammelt som henger igjen i Grafana? Jeg er litt forvirra 🤔 